### PR TITLE
remove target device enum to allow any rid to be used

### DIFF
--- a/NetCoreSsh/CustomizableSettings.cs
+++ b/NetCoreSsh/CustomizableSettings.cs
@@ -8,6 +8,6 @@
         public string Framework { get; set; }
         public string Display { get; set; }
         public bool RunAfterDeployment { get; set; }
-        public TargetDevice TargetDevice { get; set; }
+        public string TargetDevice { get; set; }
     }
 }

--- a/NetCoreSsh/IProjectPublisher.cs
+++ b/NetCoreSsh/IProjectPublisher.cs
@@ -4,6 +4,6 @@ namespace DotNetSsh
 {
     public interface IProjectPublisher
     {
-        DirectoryInfo Publish(string projectPath, TargetDevice device, string framework, string configuration);
+        DirectoryInfo Publish(string projectPath, string device, string framework, string configuration);
     }
 }

--- a/NetCoreSsh/ProjectPublisher.cs
+++ b/NetCoreSsh/ProjectPublisher.cs
@@ -1,42 +1,28 @@
-﻿using System;
+﻿using Serilog;
 using System.IO;
-using Serilog;
 
 namespace DotNetSsh
 {
     public class ProjectPublisher : IProjectPublisher
     {
-        public DirectoryInfo Publish(string projectPath, TargetDevice device, string framework, string configuration)
+        public DirectoryInfo Publish(string projectPath, string device, string framework, string configuration)
         {
             var publishPath = GetPublishPath(projectPath, device, framework, configuration);
             Log.Information("Publishing project {Project} for {TargetDevice} to path {Path}...", projectPath, device, publishPath);
-            var parameters = $@"publish ""{projectPath}"" --configuration {configuration} -r {GetRuntime(device)} -f {framework}";
+            var parameters = $@"publish ""{projectPath}"" --configuration {configuration} -r {device} -f {framework}";
             var cmd = "dotnet";
             ProcessUtils.Run(cmd, parameters);
-            
+
             return publishPath;
         }
 
-        private static DirectoryInfo GetPublishPath(string pathToProject, TargetDevice device, string framework, string configuration)
+        private static DirectoryInfo GetPublishPath(string pathToProject, string device, string framework, string configuration)
         {
             var metadata = ProjectMetadata.FromPath(pathToProject);
             var implicitPath = Path.Combine("bin", configuration, framework);
             var outputPath = metadata.OutputPath ?? implicitPath;
 
-            return new DirectoryInfo(Path.Combine(Path.GetDirectoryName(pathToProject), outputPath, GetRuntime(device), "publish"));
-        }
-
-        private static string GetRuntime(TargetDevice templateOptions)
-        {
-            switch (templateOptions)
-            {
-                case TargetDevice.Raspbian:
-                    return "linux-arm";
-                case TargetDevice.GenericLinux64:
-                    return "linux-x64";
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(templateOptions), templateOptions, null);
-            }
+            return new DirectoryInfo(Path.Combine(Path.GetDirectoryName(pathToProject), outputPath, device, "publish"));
         }
     }
 }

--- a/NetCoreSsh/TargetDevice.cs
+++ b/NetCoreSsh/TargetDevice.cs
@@ -1,8 +1,0 @@
-﻿namespace DotNetSsh
-{
-    public enum TargetDevice
-    {
-        Raspbian,
-        GenericLinux64,
-    }
-}


### PR DESCRIPTION
Hi thanks for your plugin.
I noticed that the target device is tied to the the enum values. 
I was looking to use this plugin to deploy to a generic arm64 linux device.
I propose to remove the enum, replacing it with a simple string. 
This will allows the plugin to work with any target, unless you provide a dotnet RID that does not exists.